### PR TITLE
advertise AVC caps when onH264Raw is set (WASM/external decoder)

### DIFF
--- a/plugin/rdpgfx/rdpgfx.go
+++ b/plugin/rdpgfx/rdpgfx.go
@@ -313,7 +313,12 @@ func (g *GfxHandler) OnChannelCreated() {
 func (g *GfxHandler) sendCapsAdvertise() {
 	p := &bytes.Buffer{}
 
-	if g.h264dec != nil {
+	// AVC capsets are advertised when we can deliver decoded frames either
+	// in-process (h264dec) or by handing the raw NALs off to the embedder
+	// (onH264Raw, used by the WASM build to forward to WebCodecs). Without
+	// either, the v8.0+AVCDisabled fallback below forces the server to
+	// reject RDPGFX and use legacy bitmap PDUs.
+	if g.h264dec != nil || g.onH264Raw != nil {
 		// Advertise capsets in ascending order (v8.0 → v10.7), matching
 		// rdpyqt / FreeRDP layout so servers pick the highest common version.
 		core.WriteUInt16LE(11, p) // capsSetCount


### PR DESCRIPTION
sendCapsAdvertise currently gates the AVC capset on g.h264dec != nil. When neither path is available the client deliberately advertises v8.0 + capFlagAVCDisabled to push the server back to legacy bitmap PDUs. That's correct for a build with no AVC support at all, but it also blocks an embedder that has a perfectly good external decoder wired through SetH264RawCallback.

The WASM client (grdpwasm) is the concrete case: it forwards raw NAL units to the browser's WebCodecs VideoDecoder via onH264Raw, but because h264_noop returns nil, sendCapsAdvertise falls into the AVCDisabled branch and the GFX channel is rejected before any AVC PDU is ever sent. The result is that onH264Raw is wired but never reached, and the server falls back to MS-RDPBCGR bitmap PDUs — visibly lossless on the client (RLE), heavy on bandwidth, and unrelated to the H.264 path the embedder thought it was using.                                                                                                                                                                                      

This patch widens the gate to g.h264dec != nil || g.onH264Raw != nil. The existing dispatch in decodeAVC420 / decodeAVC444 already handles the h264dec == nil && onH264Raw != nil case correctly: it parses the AVC stream, calls onH264Raw with the NAL data, and returns nil, nil, false so onWireToSurface{1,2}Decode skips the Go-side blit.