### PR TITLE
Update AMD64 Instructions

### DIFF
--- a/convert_amd64.s
+++ b/convert_amd64.s
@@ -63,11 +63,11 @@ loop555:
 	POR   X14, X6               // X6[i] = 0xFF00|B
 
 	// Interleave to produce 4 RGBA dwords each.
-	// PUNPCKLWD src,dst → dst=[dst_w0,src_w0,dst_w1,src_w1,...dst_w3,src_w3]
+	// PUNPCKLWL src,dst → dst=[dst_w0,src_w0,dst_w1,src_w1,...dst_w3,src_w3]
 	// Each dword becomes bytes [R,G,B,0xFF].
 	MOVO       X5, X7
-	PUNPCKLWD  X6, X5           // low 4 pixels  → X5
-	PUNPCKHWD  X6, X7           // high 4 pixels → X7
+	PUNPCKLWL  X6, X5           // low 4 pixels  → X5
+	PUNPCKHWL  X6, X7           // high 4 pixels → X7
 
 	MOVOU X5, (DI)
 	MOVOU X7, 16(DI)
@@ -120,8 +120,8 @@ loop565:
 	POR   X14, X6               // X6[i] = 0xFF00|B
 
 	MOVO       X5, X7
-	PUNPCKLWD  X6, X5
-	PUNPCKHWD  X6, X7
+	PUNPCKLWL  X6, X5
+	PUNPCKHWL  X6, X7
 
 	MOVOU X5, (DI)
 	MOVOU X7, 16(DI)
@@ -167,7 +167,7 @@ loop32:
 
 	// R = (src >> 16) & 0xFF  →  low byte of dest dword.
 	MOVO  X0, X2
-	PSRLD $16, X2
+	PSRLL $16, X2
 	PAND  X12, X2               // X2 = [R,0,0,0] per dword
 
 	// G stays at byte 1: src & 0x0000FF00.
@@ -177,7 +177,7 @@ loop32:
 	// B moves from byte 0 to byte 2: (src & 0xFF) << 16.
 	MOVO  X0, X4
 	PAND  X12, X4
-	PSLLD $16, X4               // X4 = [0,0,B,0] per dword
+	PSLLL $16, X4               // X4 = [0,0,B,0] per dword
 
 	POR   X3, X2
 	POR   X4, X2
@@ -188,7 +188,7 @@ loop32:
 	MOVOU 16(SI), X0
 
 	MOVO  X0, X2
-	PSRLD $16, X2
+	PSRLL $16, X2
 	PAND  X12, X2
 
 	MOVO  X0, X3
@@ -196,7 +196,7 @@ loop32:
 
 	MOVO  X0, X4
 	PAND  X12, X4
-	PSLLD $16, X4
+	PSLLL $16, X4
 
 	POR   X3, X2
 	POR   X4, X2

--- a/protocol/pdu/ycbcr_amd64.s
+++ b/protocol/pdu/ycbcr_amd64.s
@@ -82,11 +82,11 @@ loop_yco:
 	PUNPCKLBW X9, X6           // X6 = [R0,FF,R1,FF,...,R7,FF]
 
 	// Interleave BG and RA halfwords to produce BGRA dwords:
-	// PUNPCKLWD: low 4 words → [BG0,RA0,BG1,RA1,BG2,RA2,BG3,RA3]
+	// PUNPCKLWL: low 4 words → [BG0,RA0,BG1,RA1,BG2,RA2,BG3,RA3]
 	//           = bytes [B0,G0,R0,FF, B1,G1,R1,FF, B2,G2,R2,FF, B3,G3,R3,FF]
 	MOVO      X4, X11
-	PUNPCKLWD X6, X11          // X11 = low  4 BGRA pixels
-	PUNPCKHWD X6, X4           // X4  = high 4 BGRA pixels
+	PUNPCKLWL X6, X11          // X11 = low  4 BGRA pixels
+	PUNPCKHWL X6, X4           // X4  = high 4 BGRA pixels
 
 	MOVOU X11, (DI)
 	MOVOU X4,  16(DI)


### PR DESCRIPTION
Instruction set for AMD64 errors out on compile with `GOOS=linux GOARCH=amd64`

Closes #11 

## Testing
I was able to compile the binary on amd64 (github action) but was not able to verify the functionality (on mac)